### PR TITLE
CI: Build on master instead of v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "*"
   pull_request:
-    branches: ["v2"]
+    branches: ["main"]
 
 jobs:
   configure:


### PR DESCRIPTION
This setting was still "wrong" in the last PR. For the upstream repo it has to build on PRs against "master" instead of the "v2" we used in our fork.

Currently the CI will build binaries for linux (arm32, arm64 and amd64), macOS (intel and arm) and windows amd64 when a tag is pushed. When the tag name does not start with a "v", it'll be a pre-release. See https://github.com/consider-it/mqtt-record-replay/releases for an example.